### PR TITLE
refactor(registry): refactor registry-related APIs and write tests

### DIFF
--- a/sdks/python/Justfile
+++ b/sdks/python/Justfile
@@ -25,7 +25,7 @@ check:
 test:
     @echo "Testing code: Running pytest"
     uv sync --group=test
-    uv run python -m pytest --cov --cov-config=pyproject.toml --cov-report=xml
+    uv run pytest --cov --cov-config=pyproject.toml --cov-report=xml
 
 # Build wheel file
 build: clean-build

--- a/sdks/python/src/predylogic/__init__.py
+++ b/sdks/python/src/predylogic/__init__.py
@@ -1,8 +1,8 @@
 from .predicate import Predicate
-from .register import Registry, rule_def
+from .register import Registry, RegistryManager
 
 __all__ = [
     "Predicate",
     "Registry",
-    "rule_def",
+    "RegistryManager",
 ]

--- a/sdks/python/src/predylogic/register/__init__.py
+++ b/sdks/python/src/predylogic/register/__init__.py
@@ -1,3 +1,3 @@
-from .registry import GlobalRegistryManager, Registry, rule_def
+from .registry import Registry, RegistryManager
 
-__all__ = ["GlobalRegistryManager", "Registry", "rule_def"]
+__all__ = ["Registry", "RegistryManager"]

--- a/sdks/python/src/predylogic/register/errs.py
+++ b/sdks/python/src/predylogic/register/errs.py
@@ -7,6 +7,13 @@ class RegisterError(Exception):
     ...
 
 
+class RuleDefNotNamedError(RegisterError):
+    """Raised when a rule is not decorated with @rule_def."""
+
+    def __init__(self):
+        super().__init__("RuleDef must have a name.")
+
+
 class RegistryNameConflictError(RegisterError):
     """
     Raised when attempting to registry a rule with a name that is already in use.

--- a/sdks/python/src/predylogic/register/registry.py
+++ b/sdks/python/src/predylogic/register/registry.py
@@ -4,31 +4,50 @@ import inspect
 from collections.abc import Callable, Iterator, Mapping
 from functools import wraps
 from threading import RLock
-from typing import Concatenate, Generic, ParamSpec, TypeVar, cast
+from typing import TYPE_CHECKING, Generic, ParamSpec, Protocol, TypeVar, runtime_checkable
 
 from predylogic.predicate import Predicate
-from predylogic.register.errs import RegistryNameConflictError, RuleDefConflictError
-from predylogic.types import RuleDef
+from predylogic.register.errs import RegistryNameConflictError, RuleDefConflictError, RuleDefNotNamedError
+
+if TYPE_CHECKING:
+    from predylogic.types import RuleDef
 
 T_contra = TypeVar("T_contra", contravariant=True)
 P = ParamSpec("P")
 
-PredicateProducer = Callable[P, Predicate[T_contra]]
-RuleDecorator = Callable[[RuleDef[T_contra, P]], PredicateProducer]
+
+@runtime_checkable
+class PredicateProducer(Protocol[T_contra, P]):
+    """
+    Callable that produces a predicate.
+    """
+
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> Predicate[T_contra]:  # noqa: D102
+        ...
+
+
+class RuleDecorator(Protocol[T_contra]):  # noqa: D101
+    def __call__(self, fn: RuleDef[T_contra, P], /) -> PredicateProducer[T_contra, P]: ...  # noqa: D102
 
 
 class RegistryManager:
     """
     Manage registries.
+
+    # TODO: shall be responsible for a portion of the JSON Schema export functionality.
     """
 
     def __init__(self):
         self.__registers_instance: dict[str, Registry] = {}
         self.__register_lock = RLock()
 
-    def try_add_register(self, name: str, register: Registry):
+    def add_register(self, name: str, register: Registry):
         """
         Try to add a register.
+
+        Args:
+            name: The name of the register.
+            register: The register to add.
 
         Raises:
             RegisterNameConflictError: If the name is already in use.
@@ -46,23 +65,17 @@ class RegistryManager:
         return self.__registers_instance.get(name)
 
 
-GlobalRegistryManager = RegistryManager()
-
-
-class Registry(Generic[T_contra], Mapping[str, Callable[..., Predicate[T_contra]]]):
+class Registry(Generic[T_contra], Mapping[str, PredicateProducer[T_contra, ...]]):
     """
     Registry a predicate producer with a name.
     """
 
-    def __init__(self, name: str, *, _manager: RegistryManager | None = None):
+    def __init__(self, name: str):
         self.name = name
-        self.__predicates: dict[str, Callable[..., Predicate[T_contra]]] = {}
+        self.__predicates: dict[str, PredicateProducer[T_contra, ...]] = {}
         self.__lock = RLock()
 
-        manager = _manager or GlobalRegistryManager
-        manager.try_add_register(self.name, self)
-
-    def __getitem__(self, key: str) -> Callable[..., Predicate[T_contra]]:
+    def __getitem__(self, key: str) -> PredicateProducer[T_contra, ...]:
         return self.__predicates[key]
 
     def __iter__(self) -> Iterator[str]:
@@ -71,10 +84,8 @@ class Registry(Generic[T_contra], Mapping[str, Callable[..., Predicate[T_contra]
     def __len__(self) -> int:
         return len(self.__predicates)
 
-    def register(self, name: str, predicate_producer: Callable[..., Predicate[T_contra]]) -> None:
+    def _register_predicate_producer(self, name: str, predicate_producer: PredicateProducer[T_contra, ...]) -> None:
         """
-        Register a predicate producer with a name.
-
         Raises:
             RuleDefConflictError: If the name is already in use.
         """
@@ -83,39 +94,106 @@ class Registry(Generic[T_contra], Mapping[str, Callable[..., Predicate[T_contra]
                 raise RuleDefConflictError(self.name, name, self.__predicates)
             self.__predicates[name] = predicate_producer
 
+    def register(self, rule_def: RuleDef[T_contra, P], alias: str | None) -> PredicateProducer[T_contra, P]:
+        """
+        Register a RuleDef with an optional alias. Maintain the original function unchanged.
 
-class rule_def(Generic[T_contra]):  # noqa: N801
+        Args:
+            rule_def: The rule definition to register.
+            alias: An optional string representing the alias for the rule definition.
+                When registering an anonymous function, this parameter must be provided.
+
+        Returns:
+            PredicateProducer[P, T_contra]: A new predicate producer instance.
+
+        Raises:
+            RegistryNameConflictError: If the name is already in use.
+            RuleDefNotNamedError: If a rule def is not named.
+
+        Examples:
+            Register a named rule definition:
+
+            ```python
+            from typing import TypedDict
+
+            from predylogic.register import Registry
+
+
+            class UserCtx(TypedDict):
+                age: int
+
+            def is_user_over_age(user: User, age: int) -> bool:
+                return user.age >= age
+
+            registry = Registry("my_registry")
+
+            # The original function remains unchanged.
+            is_user_over_age_rule = registry.register(is_user_over_age)
+            ```
+
+        """
+
+        return RuleDefConverter(self, alias)(rule_def)
+
+    def rule_def(self, alias: str | None = None) -> RuleDefConverter[T_contra]:
+        """
+        Converts the given alias into a RuleDefConverter instance.
+
+        This method is used to create a RuleDefConverter object which can perform
+        operations related to defining rules. The optional alias parameter can be
+        supplied to distinguish or identify the rule definition.
+
+        Args:
+            alias (str | None): An optional string representing the alias for the rule
+                definition.
+
+        Returns:
+            RuleDefConverter[T_contra]: A new instance of RuleDefConverter, configured
+            with the provided alias.
+
+        Raises:
+            RegistryNameConflictError: If the name is already in use.
+            RuleDefNotNamedError: If a rule def is not named.
+
+        Examples:
+            ```python
+            from typing import TypedDict
+
+            from predylogic import Registry, Predicate
+
+
+            class UserCtx(TypedDict):
+                age: int
+
+
+            registry = Registry("my_registry")
+
+            @registry.rule_def()
+            def is_user_over_age(user: User, age: int) -> bool:
+                return user.age >= age
+
+
+            is_legal = is_user_over_age(age=18)
+
+            assert isinstance(is_legal, Predicate)
+            assert is_user_over_age(18)
+            ```
+
+        """
+
+        return RuleDefConverter(self, alias=alias)
+
+
+class RuleDefConverter(Generic[T_contra], RuleDecorator[T_contra]):
     """
-    Convert the [predylogic.types.RuleDef][] function to one that returns a Predicate[T], and add the rule to the registry.
+    Convert the [predylogic.types.RuleDef][] function to one that returns a Predicate[T]
     This will modify the signature of RuleDef.
 
     Must be used on named functions
 
     Args:
-        *registries: Registers to add the rule to.
-
-    Examples:
-        ```python
-        from typing import TypedDict
-
-
-        class UserCtx(TypedDict):
-            age: int
-
-
-        register = Register[UserCtx]("register")
-
-        @rule_def(register)
-        def is_over_age_threshold(user_ctx: UserCtx, threshold) -> bool:
-            return user_ctx.age >= threshold
-
-        legal = is_over_age_threshold(18)
-        illegal = ~legal
-
-        assert legal({"age": 18})
-        assert illegal({"age": 17})
-        ```
-
+        registry: The registry to which the rule will be added.
+        alias: Prioritize using as the name for RuleDef.
     """
 
     # XXX: Closure decorator functions are not directly defined due to type inference issues
@@ -123,21 +201,23 @@ class rule_def(Generic[T_contra]):  # noqa: N801
     # Even so, PyCharm still fails to perform correct static inference. Reveal_type and ty are relevant here.
     # https://youtrack.jetbrains.com/issue/PY-87133/Incorrect-return-type-inference-for-class-based-decorator-using-ParamSpec-and-Concatenate
 
-    def __init__(self, *registries: Registry[T_contra]):
-        self.__registries = registries
+    def __init__(self, registry: Registry[T_contra] | None = None, alias: str | None = None):
+        self.registry = registry
+        self.alias = alias
 
-    def __call__(self, fn: Callable[Concatenate[T_contra, P], bool]) -> Callable[P, Predicate[T_contra]]:
+    def __call__(self, fn: RuleDef[T_contra, P]) -> PredicateProducer[T_contra, P]:
         """
-        Convert the RuleDef function to one that returns a Predicate[T], and add the rule to the registry.
+        Convert the RuleDef function to one that returns a Predicate[T_contra], and add the rule to the registry.
         This will modify the signature of RuleDef.
 
         Args:
-            fn (RuleDef[T,P]): Rule define func. Must be a named function.
+            fn: Rule define func. Must be a named function or give an alias.
 
         Raises:
-            RuleDefConflictError: If a rule with the same fn name has already been registered.
+            RuleDefNotNamedError: If a rule def is not named.
+            RegistryNameConflictError: If the name is already in use.
+
         """
-        fn = cast("RuleDef[T_contra, P]", fn)
 
         @wraps(fn)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> Predicate[T_contra]:
@@ -150,9 +230,22 @@ class rule_def(Generic[T_contra]):  # noqa: N801
         wrapper.__annotations__ = {p.name: p.annotation for p in new_params}
         wrapper.__annotations__["return"] = Predicate
 
-        wrapper.__signature__ = inspect.Signature(parameters=new_params, return_annotation=Predicate)  # ty:ignore[unresolved-attribute]
+        wrapper.__signature__ = inspect.Signature(  # ty:ignore[unresolved-attribute]
+            parameters=new_params,
+            return_annotation=Predicate,
+        )
 
-        for register in self.__registries:
-            register.register(fn.__name__, wrapper)
+        if self._needs_alias(fn) and self.alias is None:
+            raise RuleDefNotNamedError()
+
+        rule_def_name = self.alias or fn.__name__
+
+        if self.registry is not None:
+            self.registry._register_predicate_producer(rule_def_name, wrapper)
 
         return wrapper
+
+    @staticmethod
+    def _needs_alias(fn: Callable) -> bool:
+        name = getattr(fn, "__name__", None)
+        return name is None or name in {"", "<lambda>"} or not (inspect.isfunction(fn) or inspect.ismethod(fn))

--- a/sdks/python/src/predylogic/types.py
+++ b/sdks/python/src/predylogic/types.py
@@ -1,34 +1,9 @@
-from typing import ParamSpec, Protocol, TypeVar
+from collections.abc import Callable
+from typing import Concatenate, ParamSpec, TypeAlias, TypeVar
 
 RunCtx_contra = TypeVar("RunCtx_contra", contravariant=True)
 RuleParams = ParamSpec("RuleParams")
 
+RuleDef: TypeAlias = Callable[Concatenate[RunCtx_contra, RuleParams], bool]
 
-class RuleDef(Protocol[RunCtx_contra, RuleParams]):
-    """
-    A callable that takes a context and positional and keyword arguments and returns a boolean.
-    """
-
-    __name__: str
-
-    def __call__(self, ctx: RunCtx_contra, /, *args: RuleParams.args, **kwargs: RuleParams.kwargs) -> bool:
-        """
-        Take a context and positional and keyword arguments and returns a boolean.
-
-        Args:
-            ctx: Rule context.
-            *args: Positional arguments for pass to the rule.
-            **kwargs: Keyword arguments for pass to the rule.
-
-        Examples:
-            >>> class UserCtx:
-            ...     age: int
-            ...     ...
-            >>> def is_over_age_threshold(user_ctx: UserCtx, threshold: int) -> bool:
-            ...     return user_ctx.age >= threshold
-            >>> is_over_age_threshold.__name__
-            'is_over_age_threshold'
-
-        """
-
-        ...
+__all__ = ["RuleDef"]

--- a/sdks/python/tests/test_predicate.py
+++ b/sdks/python/tests/test_predicate.py
@@ -1,45 +1,13 @@
 from __future__ import annotations
 
-import inspect
-from typing import TypedDict, get_type_hints
-
-import pytest
+from typing import TypedDict
 
 from predylogic.predicate import Predicate
-from predylogic.register import Registry, rule_def
-from predylogic.register.registry import RegistryManager
 
 
 class UserCtx(TypedDict):
     age: int
     active: bool
-
-
-@pytest.fixture
-def manager():
-    return RegistryManager()
-
-
-@pytest.fixture
-def register(manager):
-    return Registry[UserCtx]("test_register", _manager=manager)
-
-
-def test_rule_registration_and_manager_lookup(register: Registry[UserCtx], manager: RegistryManager):
-    @rule_def(register)
-    def is_user_over_age(user_ctx: UserCtx, threshold: int) -> bool:
-        return user_ctx["age"] >= threshold
-
-    assert manager.get_register("test_register") is register
-    assert manager.get_register("missing") is None
-
-    assert "is_user_over_age" in register
-    assert register["is_user_over_age"] is is_user_over_age
-
-    predicate = is_user_over_age(18)
-    assert isinstance(predicate, Predicate)
-    assert predicate({"age": 18, "active": True})
-    assert not predicate({"age": 17, "active": True})
 
 
 def test_predicate_combinations():
@@ -58,26 +26,3 @@ def test_predicate_combinations():
 
     assert not_adult({"age": 16, "active": True})
     assert not not_adult({"age": 21, "active": True})
-
-
-def test_rule_def_signature(register: Registry[UserCtx]):
-    @rule_def(register)
-    def has_minimum_age(ctx: UserCtx, threshold: int, *, strict: bool = False) -> bool:
-        return ctx["age"] >= threshold if strict else ctx["age"] > threshold - 1
-
-    sig = inspect.signature(has_minimum_age)
-    assert list(sig.parameters) == ["threshold", "strict"]
-    assert sig.parameters["threshold"].annotation == "int"
-    assert sig.parameters["strict"].annotation == "bool"
-    assert sig.parameters["strict"].default is False
-    assert sig.return_annotation is Predicate
-
-    type_hints = get_type_hints(has_minimum_age)
-    assert type_hints["threshold"] is int
-    assert type_hints["strict"] is bool
-    assert type_hints["return"] is Predicate
-
-    predicate = has_minimum_age(18, strict=True)
-    assert isinstance(predicate, Predicate)
-    assert predicate({"age": 20, "active": True})
-    assert not predicate({"age": 16, "active": True})

--- a/sdks/python/tests/test_registry.py
+++ b/sdks/python/tests/test_registry.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from predylogic.predicate import Predicate
+from predylogic.register.errs import RegistryNameConflictError, RuleDefConflictError, RuleDefNotNamedError
+from predylogic.register.registry import Registry, RegistryManager
+
+
+@dataclass
+class User:
+    age: int
+    active: bool
+
+
+@pytest.fixture
+def registry():
+    return Registry[User]("test_registry")
+
+
+def test_registry_creation():
+    registry = Registry[User]("test_registry")
+    assert registry.name == "test_registry"
+    assert len(registry) == 0
+
+
+def test_register_named_function(registry: Registry[User]):
+    def is_adult(user: User) -> bool:
+        return user.age >= 18
+
+    predicate_producer = registry.register(is_adult, None)
+    assert "is_adult" in registry
+    assert registry["is_adult"] is predicate_producer
+
+    predicate = predicate_producer()
+    assert isinstance(predicate, Predicate)
+    assert predicate(User(age=20, active=True))
+    assert not predicate(User(age=16, active=True))
+
+
+def test_register_with_alias(registry: Registry[User]):
+    def is_adult(user: User) -> bool:
+        return user.age >= 18
+
+    predicate_producer = registry.register(is_adult, "is_of_legal_age")
+    assert "is_of_legal_age" in registry
+    assert "is_adult" not in registry
+    assert registry["is_of_legal_age"] is predicate_producer
+
+
+def test_register_lambda_with_alias(registry: Registry[User]):
+    predicate_producer = registry.register(lambda user, age: user.age > age, "is_older_than")
+    assert "is_older_than" in registry
+    predicate = predicate_producer(25)
+    assert predicate(User(age=30, active=True))
+    assert not predicate(User(age=20, active=True))
+
+
+def test_register_lambda_without_alias_raises_error(registry: Registry[User]):
+    with pytest.raises(RuleDefNotNamedError):
+        registry.register(lambda user: user.active, None)
+
+
+def test_register_duplicate_name_raises_error(registry: Registry[User]):
+    def is_active(user: User) -> bool:
+        return user.active
+
+    registry.register(is_active, None)
+    with pytest.raises(RuleDefConflictError):
+        registry.register(is_active, None)
+
+
+def test_rule_def_decorator(registry: Registry[User]):
+    @registry.rule_def()
+    def is_active(user: User) -> bool:
+        return user.active
+
+    assert "is_active" in registry
+    predicate = is_active()
+    assert isinstance(predicate, Predicate)
+    assert predicate(User(age=20, active=True))
+    assert not predicate(User(age=20, active=False))
+
+
+def test_rule_def_decorator_with_alias(registry: Registry[User]):
+    @registry.rule_def("is_currently_active")
+    def is_active(user: User) -> bool:
+        return user.active
+
+    assert "is_currently_active" in registry
+    assert "is_active" not in registry
+
+
+def test_registry_manager():
+    manager = RegistryManager()
+    registry1 = Registry[User]("registry1")
+    registry2 = Registry[User]("registry2")
+
+    manager.add_register("registry1", registry1)
+    manager.add_register("registry2", registry2)
+
+    assert manager.get_register("registry1") is registry1
+    assert manager.get_register("registry2") is registry2
+    assert manager.get_register("non_existent") is None
+
+
+def test_registry_manager_add_duplicate_name_raises_error():
+    manager = RegistryManager()
+    registry1 = Registry[User]("registry1")
+    manager.add_register("registry1", registry1)
+
+    with pytest.raises(RegistryNameConflictError):
+        manager.add_register("registry1", registry1)


### PR DESCRIPTION
Restructure registry management and enhance error definitions:
- Replace GlobalRegistryManager with instance-based RegistryManager
- Introduce RuleDefNotNamedError for unnamed rule definitions
- Update method signatures for clarity and consistency
- Improve type hints and documentation for better usability


## Description

Closes #6 
