### PR TITLE
chore(tach): simplify layer config and enable cycle check

### DIFF
--- a/sdks/python/tach.toml
+++ b/sdks/python/tach.toml
@@ -1,30 +1,25 @@
-exclude = ["**/*__pycache__", "**/*egg-info", "**/docs", "**/tests", "**/.venv"]
+exclude = ["**/*__pycache__", "**/*egg-info", "**/tests", "**/.venv"]
+forbid_circular_dependencies = true
 ignore_type_checking_imports = true
-interfaces = []
 layers = ["rule_engine", "register", "predicate", "trace", "typedefs"]
 source_roots = ["src"]
 
 [[modules]]
-depends_on = []
-layer = "typedefs"
-path = "predylogic.typedefs"
+layer = "rule_engine"
+path = "predylogic.rule_engine"
 
 [[modules]]
-depends_on = []
 layer = "register"
 path = "predylogic.register"
 
 [[modules]]
-depends_on = []
-layer = "trace"
-path = "predylogic.trace"
-
-[[modules]]
-depends_on = []
 layer = "predicate"
 path = "predylogic.predicate"
 
 [[modules]]
-depends_on = []
-layer = "rule_engine"
-path = "predylogic.rule_engine"
+layer = "trace"
+path = "predylogic.trace"
+
+[[modules]]
+layer = "typedefs"
+path = "predylogic.typedefs"


### PR DESCRIPTION

## Description

Remove redundant `depends_on = []` on each module (no same-layer peers
to constrain) and the empty `interfaces = []`. Enable
`forbid_circular_dependencies` so intra-layer file cycles are caught on
top of tach's cross-layer enforcement. Drop `**/docs` from `exclude`
since it lives outside `source_roots = ["src"]`.

