### PR TITLE
migrate to mise-managed and update tool chain

### DIFF
--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -1,15 +1,11 @@
 name: "Setup Python Environment"
-description: "Set up Python environment for the given Python version"
+description: "Install toolchain via mise and sync Python deps"
 
 inputs:
   python-version:
     description: "Python version to use"
     required: true
     default: "3.10"
-  uv-version:
-    description: "uv version to use"
-    required: true
-    default: "0.9.21"
 
 runs:
   using: "composite"
@@ -18,15 +14,10 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v7
+    - name: Install toolchain (uv, just, prek, git-cliff)
+      uses: jdx/mise-action@v3
       with:
-        version: ${{ inputs.uv-version }}
-        enable-cache: 'true'
-        cache-suffix: ${{ matrix.python-version }}
-
-    - name: Install just
-      uses: extractions/setup-just@v3
+        cache: true
 
     - name: Install Python dependencies
       run: uv sync --frozen --all-packages --group=dev --group=test

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -20,16 +20,13 @@ jobs:
       - name: Check out
         uses: actions/checkout@v6
 
-      - uses: actions/cache@v5
-        with:
-          path: ~/.cache/pre-commit
-          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-
       - name: Set up the environment
         uses: ./.github/actions/setup-python-env
 
-      - name: Run pre-commit
-        run: uv run pre-commit run --all-files
+      - name: Run prek
+        uses: j178/prek-action@v2
+        with:
+          args: --all-files --show-diff-on-failure
 
       - name: Run checks
         run: just py-check

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -25,8 +25,6 @@ jobs:
 
       - name: Run prek
         uses: j178/prek-action@v2
-        with:
-          args: --all-files --show-diff-on-failure
 
       - name: Run checks
         run: just py-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,8 +34,8 @@ repos:
         name: ty check
         entry: uv run ty check
         language: system
-        types: [ python, pyi ]
-        always_run: true
+        pass_filenames: false
+        types_or: [ python, pyi ]
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.30.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     hooks:
       - id: ty
         name: ty check
-        entry: uv run ty check
+        entry: uv run --no-sync ty check
         language: system
         pass_filenames: false
         types_or: [ python, pyi ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,79 +46,79 @@ If you are proposing a new feature:
 # Get Started!
 
 Ready to contribute? Here's how to set up `predylogic` for local development.
-Please note this documentation assumes you already have **`uv`**, **`just`**, and **`Git`** installed and ready to go.
 
-1. Fork the `predylogic` repo on GitHub.
+This project uses **[`mise`](https://mise.jdx.dev)** to manage its toolchain (`uv`, `just`, `prek`, `git-cliff`).
+The only prerequisites you need on your machine are **`mise`** and **`Git`** — everything else is pinned in `mise.toml`
+and installed automatically.
 
-2. Clone your fork locally:
+1. Fork the `predylogic` repo on GitHub and clone your fork:
 
-```bash
-cd <directory_in_which_repo_should_be_created>
-git clone git@github.com:YOUR_NAME/predylogic.git
-```
+    ```bash
+    git clone git@github.com:YOUR_NAME/predylogic.git
+    cd predylogic
+    ```
 
-3. Navigate into the directory:
+2. Trust and install the toolchain:
 
-```bash
-cd predylogic
-```
+    ```bash
+    mise trust
+    mise install
+    ```
 
-4. Install the environment and hooks.
-   This command will use `uv` to create a virtual environment and install `pre-commit` hooks (including commit-message
-   linting):
+    This reads `mise.toml` and installs `uv`, `just`, `prek`, and `git-cliff` at the versions declared there. Make sure
+    mise shims are active in your shell (`mise activate`, see the mise docs).
 
-```bash
-just install
-```
+3. Install Python dependencies and the git hooks:
 
-5. Create a branch for local development:
+    ```bash
+    just install
+    ```
 
-```bash
-git checkout -b name-of-your-bugfix-or-feature
-```
+    This runs `uv sync` and installs `prek` hooks for both `pre-commit` and `commit-msg`.
 
-Now you can make your changes locally.
+4. Create a branch for local development:
 
-6. Don't forget to add test cases for your added functionality to the `tests` directory.
-7. When you're done making changes, run the code quality suite.
-   This runs type checking (`ty`), linting (`ruff`), and dependency checks (`deptry`, `tach`):
+    ```bash
+    git checkout -b name-of-your-bugfix-or-feature
+    ```
 
-```bash
-just py-check
-```
+5. Add tests for any new behavior under `sdks/python/tests/`.
 
-8. Validate that all unit tests are passing:
+6. Run the quality suite — this runs type checking (`ty`), linting (`ruff`), and dependency checks (`deptry`, `tach`):
 
-```bash
-just py-test
-```
+    ```bash
+    just py-check
+    ```
 
-9. (Optional) If you modified the documentation, you can preview it locally:
+7. Run the tests:
 
-For example, when modifying Python documentation:
+    ```bash
+    just py-test
+    ```
 
-```bash
-just docs-serve
-```
+8. (Optional) Preview documentation changes:
 
-10. Commit your changes and push your branch to GitHub.
-    **Note:** We follow **Conventional Commits**. Your commit message will be verified by the `commit-msg` hook
-    installed in step 4.
+    ```bash
+    just docs-serve
+    ```
 
-```bash
-git add .
-git commit -m "feat: add support for new predicate types"
-# or "fix: resolve issue with registry lookup"
-git push origin name-of-your-bugfix-or-feature
-```
+9. Stage and commit your changes. **Stage specific files** rather than `git add .` to avoid pulling in local artifacts
+   (profile output, coverage files, notes). We follow **Conventional Commits**; the `commit-msg` hook installed in
+   step 3 will reject commits that don't conform:
 
-11. Submit a pull request through the GitHub website.
+    ```bash
+    git add path/to/changed/files
+    git commit -m "feat: add support for new predicate types"
+    git push origin name-of-your-bugfix-or-feature
+    ```
+
+10. Open a pull request against `main` on GitHub.
 
 # Pull Request Guidelines
 
 Before you submit a pull request, check that it meets these guidelines:
 
-1. The pull request should include tests.
-2. The pull request must pass all CI/CD checks (linting, testing, type checking).
-3. If the pull request adds functionality, the docs should be updated.
-   Put your new functionality into a function with a docstring, and add the feature to the list in `README.md`.
+1. The pull request includes tests for the new or changed behavior.
+2. The pull request passes all CI checks (`prek`, `ty`, `ruff`, `deptry`, `tach`, pytest across the Python matrix).
+3. Public API changes are reflected in Google-style docstrings on `src/`, and — if user-visible — in `docs/` and the
+   `README.md` feature narrative.

--- a/Justfile
+++ b/Justfile
@@ -9,8 +9,8 @@ default:
 # Install dependencies and pre-commit hooks
 install *groups="dev test":
     uv sync --all-packages {{ if groups == "all" { "--all-groups" } else { prepend("--group ", groups) } }}
-    uv run pre-commit install
-    uv run pre-commit install --hook-type commit-msg
+    prek install --overwrite
+    prek install --overwrite --hook-type commit-msg
 
 # Run Python code quality checks
 py-check:

--- a/Justfile
+++ b/Justfile
@@ -14,8 +14,6 @@ install *groups="dev test":
 
 # Run Python code quality checks
 py-check:
-    @echo "Checking lock file consistency with 'pyproject.toml'"
-    uv lock --locked
     @echo "Static type checking: Running ty"
     uv run ty check
     @echo "Linting: Running ruff"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,5 @@
+[tools]
+git-cliff = "latest"
+just = "latest"
+prek = "latest"
+uv = "latest"


### PR DESCRIPTION
## Description

 Switch the dev and CI toolchains from pip-installed `pre-commit` to the
    Rust-based `prek`, with all tool versions pinned in a checked-in
    `mise.toml`. Contributors now only need `mise` and `git` on their
    machine; `uv`, `just`, `prek`, and `git-cliff` are installed via
    `mise install`.


Closes # (issue number)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Chore (tooling, config, internal cleanup)

## Checklist

- [ ] My code follows the style guidelines of this project (`just py-check` passes)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`just test`)
- [x] I have updated the `CHANGELOG.md` (if applicable)

## Implementation Details / Benchmarks
