### PR TITLE
fix(trace): flat N-ary trace trees with correct child order

### DIFF
--- a/sdks/python/src/predylogic/predicate/predicate.py
+++ b/sdks/python/src/predylogic/predicate/predicate.py
@@ -495,7 +495,8 @@ class Compiler:
                 # N-ary back (Mixed mode)
                 if not children:
                     break
-                chain.extend(children[1:])
+                # reversed so stack LIFO restores left-to-right evaluation order
+                chain.extend(reversed(children[1:]))
                 current = children[0]
 
         chain.append(current)
@@ -568,14 +569,13 @@ class Compiler:
                 match node:
                     case _PredicateLeaf() as p:
                         results.append(self._create_ast_leaf(p, fallback))
-                    case (
-                        _PredicateAnd(node_type=node_type, children=children)
-                        | _PredicateOr(node_type=node_type, children=children)
-                    ):
-                        flat_tuple = ("FLATTENED", node_type, len(children))
+                    case _PredicateAnd(node_type=node_type, children=_) | _PredicateOr(node_type=node_type, children=_):
                         # NOTE: _collect_chain collects right-siblings, resulting in reverse execution order.
                         #  Stack extension restores the Left-to-Right order for AST generation.
-                        chain = self._collect_chain(node, node_type)
+                        #  Walking through same-type descendants can return MORE elements than the
+                        #  top-level node's children — the flatten count must reflect the walked length.
+                        chain = list(self._collect_chain(node, node_type))
+                        flat_tuple = ("FLATTENED", node_type, len(chain))
                         stack.append(self.CompileStack(flat_tuple, visited=False, fallback=fallback))
 
                         child_fallback = node_type != "or"
@@ -637,37 +637,46 @@ class Compiler:
         if self.short_circuit:
 
             def _rt_and(first: Trace[T_contra], *thunks: Callable[[], Trace[T_contra]]) -> Trace[T_contra]:
-                res = first
+                children: list[Trace[T_contra]] = [first]
+                if not first.success:
+                    return Trace(success=False, operator="and", children=tuple(children))
                 for thunk in thunks:
-                    if not res.success:
-                        return Trace(success=False, operator="and", children=(res,))
-                    other = thunk()
-                    res = res & other
-                return res
+                    child = thunk()
+                    children.append(child)
+                    if not child.success:
+                        return Trace(success=False, operator="and", children=tuple(children))
+                return Trace(success=True, operator="and", children=tuple(children))
 
             def _rt_or(first: Trace[T_contra], *thunks: Callable[[], Trace[T_contra]]) -> Trace[T_contra]:
-                res = first
+                children: list[Trace[T_contra]] = [first]
+                if first.success:
+                    return Trace(success=True, operator="or", children=tuple(children))
                 for thunk in thunks:
-                    if res.success:
-                        return Trace(success=True, operator="or", children=(res,))
-
-                    other = thunk()
-                    res = res | other
-                return res
+                    child = thunk()
+                    children.append(child)
+                    if child.success:
+                        return Trace(success=True, operator="or", children=tuple(children))
+                return Trace(success=False, operator="or", children=tuple(children))
 
         else:
 
             def _rt_and(first: Trace[T_contra], *thunks: Callable[[], Trace[T_contra]]) -> Trace[T_contra]:
-                res = first
+                children: list[Trace[T_contra]] = [first]
+                success = first.success
                 for thunk in thunks:
-                    res = res & thunk()
-                return res
+                    child = thunk()
+                    children.append(child)
+                    success = success and child.success
+                return Trace(success=success, operator="and", children=tuple(children))
 
             def _rt_or(first: Trace[T_contra], *thunks: Callable[[], Trace[T_contra]]) -> Trace[T_contra]:
-                res = first
+                children: list[Trace[T_contra]] = [first]
+                success = first.success
                 for thunk in thunks:
-                    res = res | thunk()
-                return res
+                    child = thunk()
+                    children.append(child)
+                    success = success or child.success
+                return Trace(success=success, operator="or", children=tuple(children))
 
         self._context[RT_AND] = _rt_and
         self._context[RT_OR] = _rt_or

--- a/sdks/python/src/predylogic/trace/trace.py
+++ b/sdks/python/src/predylogic/trace/trace.py
@@ -42,8 +42,9 @@ class DefaultTraceStyle(TraceStyle):
         """
         indent = "  " * level
 
-        if trace.node and trace.node.desc:
-            label = trace.node.desc
+        node_label = (trace.node.desc or trace.node.name) if trace.node else None
+        if node_label:
+            label = node_label
             if trace.operator in ("and", "or", "not"):
                 label = f"{label} <{trace.operator.upper()}>"
         else:

--- a/sdks/python/tests/test_trace.py
+++ b/sdks/python/tests/test_trace.py
@@ -42,23 +42,19 @@ def leaf_raiser(name: str, exc: Exception):
 
 CTX: Ctx = {"value": 1}
 
-
-def collect_operators(t: Trace) -> list[str]:
-    """Flatten all operators in a trace tree (pre-order)."""
-    ops = [t.operator]
-    for c in t.children:
-        ops.extend(collect_operators(c))
-    return ops  # ty:ignore[invalid-return-type]
+# Shape: (operator, success, name, children_shapes)
+Shape = tuple[str, bool, str | None, tuple["Shape", ...]]
 
 
-def collect_leaf_names(t: Trace) -> list[str]:
-    """Collect names of all leaf nodes in pre-order."""
-    names = []
-    if t.operator == "leaf" and t.node and t.node.name:
-        names.append(t.node.name)
-    for c in t.children:
-        names.extend(collect_leaf_names(c))
-    return names
+def trace_shape(t: Trace) -> Shape:
+    """Extract the full structural snapshot of a Trace tree.
+
+    Returns (operator, success, name, (child_shapes...)).
+    A single assert on this tuple locks down structure, order, identity, and success.
+    """
+    name = t.node.name if t.node else None
+    children = tuple(trace_shape(c) for c in t.children)
+    return t.operator, t.success, name, children
 
 
 # ============================================================================
@@ -74,45 +70,45 @@ class TestTraceTreeStructure:
         p = leaf("A", result=True)
         t = p(CTX, trace=True)
 
-        assert isinstance(t, Trace)
-        assert t.operator == "leaf"
-        assert t.success is True
-        assert t.children == ()
-        assert t.node is not None
-        assert t.node.name == "A"
+        assert trace_shape(t) == ("leaf", True, "A", ())
 
     def test_two_children_and(self):
         """AND with 2 children — baseline, should be flat."""
         p = all_of([leaf("A", result=True), leaf("B", result=False)])
         t = p(CTX, trace=True, short_circuit=False)
 
-        assert t.operator == "and"
-        assert t.success is False
-        assert len(t.children) == 2
-        assert t.children[0].operator == "leaf"
-        assert t.children[1].operator == "leaf"
+        assert trace_shape(t) == (
+            "and",
+            False,
+            None,
+            (
+                ("leaf", True, "A", ()),
+                ("leaf", False, "B", ()),
+            ),
+        )
 
     def test_two_children_or(self):
         """OR with 2 children — baseline, should be flat."""
         p = any_of([leaf("A", result=False), leaf("B", result=True)])
         t = p(CTX, trace=True, short_circuit=False)
 
-        assert t.operator == "or"
-        assert t.success is True
-        assert len(t.children) == 2
-        assert t.children[0].operator == "leaf"
-        assert t.children[1].operator == "leaf"
+        assert trace_shape(t) == (
+            "or",
+            True,
+            None,
+            (
+                ("leaf", False, "A", ()),
+                ("leaf", True, "B", ()),
+            ),
+        )
 
     def test_three_children_and_is_flat(self):
         """
         CRITICAL: all_of([A, B, C]) must produce a flat AND node with 3 children,
         not a left-leaning nested tree.
 
-        Expected:
-            and -> [A, B, C]
-
-        NOT:
-            and -> [and -> [A, B], C]
+        Expected:  and -> [A, B, C]
+        NOT:       and -> [and -> [A, B], C]
         """
         p = all_of([
             leaf("A", result=True),
@@ -121,18 +117,19 @@ class TestTraceTreeStructure:
         ])
         t = p(CTX, trace=True, short_circuit=False)
 
-        assert t.operator == "and"
-        assert t.success is False
-        assert len(t.children) == 3, (
-            f"Expected 3 flat children, got {len(t.children)}. Operators: {[c.operator for c in t.children]}"
+        assert trace_shape(t) == (
+            "and",
+            False,
+            None,
+            (
+                ("leaf", True, "A", ()),
+                ("leaf", False, "B", ()),
+                ("leaf", True, "C", ()),
+            ),
         )
-        assert all(c.operator == "leaf" for c in t.children)
-        assert collect_leaf_names(t) == ["A", "B", "C"]
 
     def test_three_children_or_is_flat(self):
-        """
-        CRITICAL: any_of([A, B, C]) must produce a flat OR node with 3 children.
-        """
+        """CRITICAL: any_of([A, B, C]) must produce a flat OR node with 3 children."""
         p = any_of([
             leaf("A", result=False),
             leaf("B", result=True),
@@ -140,13 +137,16 @@ class TestTraceTreeStructure:
         ])
         t = p(CTX, trace=True, short_circuit=False)
 
-        assert t.operator == "or"
-        assert t.success is True
-        assert len(t.children) == 3, (
-            f"Expected 3 flat children, got {len(t.children)}. Operators: {[c.operator for c in t.children]}"
+        assert trace_shape(t) == (
+            "or",
+            True,
+            None,
+            (
+                ("leaf", False, "A", ()),
+                ("leaf", True, "B", ()),
+                ("leaf", False, "C", ()),
+            ),
         )
-        assert all(c.operator == "leaf" for c in t.children)
-        assert collect_leaf_names(t) == ["A", "B", "C"]
 
     def test_four_children_and_is_flat(self):
         """4 children AND — no nesting at any level."""
@@ -158,10 +158,17 @@ class TestTraceTreeStructure:
         ])
         t = p(CTX, trace=True, short_circuit=False)
 
-        assert t.operator == "and"
-        assert len(t.children) == 4
-        assert all(c.operator == "leaf" for c in t.children)
-        assert t.success is False
+        assert trace_shape(t) == (
+            "and",
+            False,
+            None,
+            (
+                ("leaf", True, "A", ()),
+                ("leaf", True, "B", ()),
+                ("leaf", True, "C", ()),
+                ("leaf", False, "D", ()),
+            ),
+        )
 
     def test_four_children_or_is_flat(self):
         """4 children OR — no nesting at any level."""
@@ -173,40 +180,56 @@ class TestTraceTreeStructure:
         ])
         t = p(CTX, trace=True, short_circuit=False)
 
-        assert t.operator == "or"
-        assert len(t.children) == 4
-        assert all(c.operator == "leaf" for c in t.children)
-        assert t.success is True
+        assert trace_shape(t) == (
+            "or",
+            True,
+            None,
+            (
+                ("leaf", False, "A", ()),
+                ("leaf", False, "B", ()),
+                ("leaf", True, "C", ()),
+                ("leaf", False, "D", ()),
+            ),
+        )
 
     def test_chained_and_operator_is_flat(self):
-        """
-        A & B & C via operator chaining should also produce flat trace.
-        """
-        a = leaf("A", result=True)
-        b = leaf("B", result=True)
-        c = leaf("C", result=False)
-
-        p = a & b & c
+        """A & B & C via operator chaining should also produce flat trace."""
+        p = leaf("A", result=True) & leaf("B", result=True) & leaf("C", result=False)
         t = p(CTX, trace=True, short_circuit=False)
 
-        assert t.operator == "and"
-        assert len(t.children) == 3
-        assert all(c.operator == "leaf" for c in t.children)
+        assert trace_shape(t) == (
+            "and",
+            False,
+            None,
+            (
+                ("leaf", True, "A", ()),
+                ("leaf", True, "B", ()),
+                ("leaf", False, "C", ()),
+            ),
+        )
 
     def test_chained_or_operator_is_flat(self):
-        """
-        A | B | C via operator chaining should also produce flat trace.
-        """
-        a = leaf("A", result=False)
-        b = leaf("B", result=False)
-        c = leaf("C", result=True)
-
-        p = a | b | c
+        """A | B | C via operator chaining should also produce flat trace."""
+        p = leaf("A", result=False) | leaf("B", result=False) | leaf("C", result=True)
         t = p(CTX, trace=True, short_circuit=False)
 
-        assert t.operator == "or"
-        assert len(t.children) == 3
-        assert all(c.operator == "leaf" for c in t.children)
+        assert trace_shape(t) == (
+            "or",
+            True,
+            None,
+            (
+                ("leaf", False, "A", ()),
+                ("leaf", False, "B", ()),
+                ("leaf", True, "C", ()),
+            ),
+        )
+
+    def test_five_children_all_same_result(self):
+        """5 children AND, all True — verify no degenerate nesting."""
+        p = all_of([leaf(c, result=True) for c in "ABCDE"])
+        t = p(CTX, trace=True, short_circuit=False)
+
+        assert trace_shape(t) == ("and", True, None, tuple(("leaf", True, c, ()) for c in "ABCDE"))
 
 
 # ============================================================================
@@ -225,13 +248,23 @@ class TestTraceNestedComposition:
         ])
         t = p(CTX, trace=True, short_circuit=False)
 
-        assert t.operator == "and"
-        assert t.success is True
-        assert len(t.children) == 2
-
-        assert t.children[0].operator == "leaf"
-        assert t.children[1].operator == "or"
-        assert len(t.children[1].children) == 2
+        assert trace_shape(t) == (
+            "and",
+            True,
+            None,
+            (
+                ("leaf", True, "A", ()),
+                (
+                    "or",
+                    True,
+                    None,
+                    (
+                        ("leaf", False, "B", ()),
+                        ("leaf", True, "C", ()),
+                    ),
+                ),
+            ),
+        )
 
     def test_or_containing_and(self):
         """OR(AND(A, B), C) — two levels."""
@@ -241,24 +274,59 @@ class TestTraceNestedComposition:
         ])
         t = p(CTX, trace=True, short_circuit=False)
 
-        assert t.operator == "or"
-        assert t.success is True
-        assert len(t.children) == 2
-
-        assert t.children[0].operator == "and"
-        assert t.children[0].success is False
-        assert t.children[1].operator == "leaf"
+        assert trace_shape(t) == (
+            "or",
+            True,
+            None,
+            (
+                (
+                    "and",
+                    False,
+                    None,
+                    (
+                        ("leaf", False, "A", ()),
+                        ("leaf", True, "B", ()),
+                    ),
+                ),
+                ("leaf", True, "C", ()),
+            ),
+        )
 
     def test_not_wrapping_and(self):
         """NOT(AND(A, B)) — not node with and child."""
         p = ~all_of([leaf("A", result=True), leaf("B", result=True)])
         t = p(CTX, trace=True, short_circuit=False)
 
-        assert t.operator == "not"
-        assert t.success is False
-        assert len(t.children) == 1
-        assert t.children[0].operator == "and"
-        assert t.children[0].success is True
+        assert trace_shape(t) == (
+            "not",
+            False,
+            None,
+            (
+                (
+                    "and",
+                    True,
+                    None,
+                    (
+                        ("leaf", True, "A", ()),
+                        ("leaf", True, "B", ()),
+                    ),
+                ),
+            ),
+        )
+
+    def test_not_wrapping_leaf(self):
+        """NOT(A) — simple negation."""
+        p = ~leaf("A", result=True)
+        t = p(CTX, trace=True)
+
+        assert trace_shape(t) == ("not", False, None, (("leaf", True, "A", ()),))
+
+    def test_double_not(self):
+        """NOT(NOT(A)) — double negation."""
+        p = ~~leaf("A", result=True)
+        t = p(CTX, trace=True)
+
+        assert trace_shape(t) == ("not", True, None, (("not", False, None, (("leaf", True, "A", ()),)),))
 
     def test_three_level_nesting(self):
         """AND(A, OR(B, AND(C, D))) — three levels deep."""
@@ -271,18 +339,31 @@ class TestTraceNestedComposition:
         ])
         t = p(CTX, trace=True, short_circuit=False)
 
-        assert t.operator == "and"
-        assert t.success is True
-        assert len(t.children) == 2
-
-        or_node = t.children[1]
-        assert or_node.operator == "or"
-        assert len(or_node.children) == 2
-
-        and_inner = or_node.children[1]
-        assert and_inner.operator == "and"
-        assert len(and_inner.children) == 2
-        assert all(c.operator == "leaf" for c in and_inner.children)
+        assert trace_shape(t) == (
+            "and",
+            True,
+            None,
+            (
+                ("leaf", True, "A", ()),
+                (
+                    "or",
+                    True,
+                    None,
+                    (
+                        ("leaf", False, "B", ()),
+                        (
+                            "and",
+                            True,
+                            None,
+                            (
+                                ("leaf", True, "C", ()),
+                                ("leaf", True, "D", ()),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
 
     def test_nary_and_containing_nary_or(self):
         """
@@ -300,14 +381,58 @@ class TestTraceNestedComposition:
         ])
         t = p(CTX, trace=True, short_circuit=False)
 
-        assert t.operator == "and"
-        assert t.success is True
-        assert len(t.children) == 3
+        assert trace_shape(t) == (
+            "and",
+            True,
+            None,
+            (
+                ("leaf", True, "A", ()),
+                ("leaf", True, "B", ()),
+                (
+                    "or",
+                    True,
+                    None,
+                    (
+                        ("leaf", False, "C", ()),
+                        ("leaf", False, "D", ()),
+                        ("leaf", True, "E", ()),
+                    ),
+                ),
+            ),
+        )
 
-        or_node = t.children[2]
-        assert or_node.operator == "or"
-        assert len(or_node.children) == 3
-        assert all(c.operator == "leaf" for c in or_node.children)
+    def test_mixed_operators_complex(self):
+        """OR(AND(A, B, C), NOT(D), E) — mixed N-ary with not."""
+        p = any_of([
+            all_of([
+                leaf("A", result=True),
+                leaf("B", result=True),
+                leaf("C", result=False),
+            ]),
+            ~leaf("D", result=True),
+            leaf("E", result=True),
+        ])
+        t = p(CTX, trace=True, short_circuit=False)
+
+        assert trace_shape(t) == (
+            "or",
+            True,
+            None,
+            (
+                (
+                    "and",
+                    False,
+                    None,
+                    (
+                        ("leaf", True, "A", ()),
+                        ("leaf", True, "B", ()),
+                        ("leaf", False, "C", ()),
+                    ),
+                ),
+                ("not", False, None, (("leaf", True, "D", ()),)),
+                ("leaf", True, "E", ()),
+            ),
+        )
 
 
 # ============================================================================
@@ -329,10 +454,11 @@ class TestTraceShortCircuit:
 
         assert t.operator == "and"
         assert t.success is False
-        evaluated = collect_leaf_names(t)
-        assert "A" in evaluated
-        assert "B" not in evaluated
-        assert "C" not in evaluated
+        # Only A should be evaluated — B and C skipped
+        leaf_names = set(self._collect_leaf_names(t))
+        assert "A" in leaf_names
+        assert "B" not in leaf_names
+        assert "C" not in leaf_names
 
     def test_or_short_circuits_on_first_true(self):
         """OR(T, F, F) with short_circuit=True — only first child evaluated."""
@@ -345,10 +471,10 @@ class TestTraceShortCircuit:
 
         assert t.operator == "or"
         assert t.success is True
-        evaluated = collect_leaf_names(t)
-        assert "A" in evaluated
-        assert "B" not in evaluated
-        assert "C" not in evaluated
+        leaf_names = set(self._collect_leaf_names(t))
+        assert "A" in leaf_names
+        assert "B" not in leaf_names
+        assert "C" not in leaf_names
 
     def test_and_short_circuits_on_second(self):
         """AND(T, F, T) — evaluates A and B, stops at B."""
@@ -360,13 +486,28 @@ class TestTraceShortCircuit:
         t = p(CTX, trace=True, short_circuit=True)
 
         assert t.success is False
-        evaluated = collect_leaf_names(t)
-        assert "A" in evaluated
-        assert "B" in evaluated
-        assert "C" not in evaluated
+        leaf_names = set(self._collect_leaf_names(t))
+        assert "A" in leaf_names
+        assert "B" in leaf_names
+        assert "C" not in leaf_names
 
-    def test_no_short_circuit_evaluates_all(self):
-        """AND(F, T, T) with short_circuit=False — all children evaluated."""
+    def test_or_short_circuits_on_second(self):
+        """OR(F, T, F) — evaluates A and B, stops at B."""
+        p = any_of([
+            leaf("A", result=False),
+            leaf("B", result=True),
+            leaf("C", result=False),
+        ])
+        t = p(CTX, trace=True, short_circuit=True)
+
+        assert t.success is True
+        leaf_names = set(self._collect_leaf_names(t))
+        assert "A" in leaf_names
+        assert "B" in leaf_names
+        assert "C" not in leaf_names
+
+    def test_no_short_circuit_evaluates_all_and(self):
+        """AND(F, T, T) with short_circuit=False — all children evaluated in order."""
         p = all_of([
             leaf("A", result=False),
             leaf("B", result=True),
@@ -375,8 +516,44 @@ class TestTraceShortCircuit:
         t = p(CTX, trace=True, short_circuit=False)
 
         assert t.success is False
-        evaluated = collect_leaf_names(t)
-        assert evaluated == ["A", "B", "C"]
+        assert self._collect_leaf_names(t) == ["A", "B", "C"]
+
+    def test_no_short_circuit_evaluates_all_or(self):
+        """OR(T, F, F) with short_circuit=False — all children evaluated in order."""
+        p = any_of([
+            leaf("A", result=True),
+            leaf("B", result=False),
+            leaf("C", result=False),
+        ])
+        t = p(CTX, trace=True, short_circuit=False)
+
+        assert t.success is True
+        assert self._collect_leaf_names(t) == ["A", "B", "C"]
+
+    def test_short_circuit_nested_and_in_or(self):
+        """OR(AND(T, F), T) with short_circuit — inner AND fails, outer OR tries next."""
+        p = any_of([
+            all_of([leaf("A", result=True), leaf("B", result=False)]),
+            leaf("C", result=True),
+        ])
+        t = p(CTX, trace=True, short_circuit=True)
+
+        assert t.success is True
+        # AND(A, B) should evaluate both (A=T then B=F), then OR tries C
+        leaf_names = set(self._collect_leaf_names(t))
+        assert "A" in leaf_names
+        assert "B" in leaf_names
+        assert "C" in leaf_names
+
+    @staticmethod
+    def _collect_leaf_names(t: Trace) -> list[str]:
+        """Recursively collect names of all leaf trace nodes (pre-order)."""
+        names: list[str] = []
+        if t.operator == "leaf" and t.node and t.node.name:
+            names.append(t.node.name)
+        for c in t.children:
+            names.extend(TestTraceShortCircuit._collect_leaf_names(c))
+        return names
 
 
 # ============================================================================
@@ -401,7 +578,6 @@ class TestTraceFailSkip:
         skip_child = t.children[0]
         assert skip_child.operator == "SKIP"
         assert skip_child.success is True  # AND identity
-        assert skip_child.error is not None
         assert isinstance(skip_child.error, ValueError)
         assert skip_child.node is not None
         assert skip_child.node.name == "A"
@@ -423,7 +599,7 @@ class TestTraceFailSkip:
         assert isinstance(skip_child.error, ValueError)
 
     def test_skip_in_nary_and(self):
-        """fail_skip with 3 children AND — all evaluated, skip is flat."""
+        """fail_skip with 3 children AND — all evaluated, structure is flat."""
         p = all_of([
             leaf("A", result=True),
             leaf_raiser("B", ValueError("boom")),
@@ -431,14 +607,47 @@ class TestTraceFailSkip:
         ])
         t = p(CTX, trace=True, short_circuit=False, fail_skip=(ValueError,))
 
-        assert t.operator == "and"
-        assert t.success is True  # A=True, B=True(skip identity), C=True
-        assert len(t.children) == 3
+        assert trace_shape(t) == (
+            "and",
+            True,
+            None,
+            (
+                ("leaf", True, "A", ()),
+                ("SKIP", True, "B", ()),  # AND identity fallback
+                ("leaf", True, "C", ()),
+            ),
+        )
 
-        assert t.children[0].operator == "leaf"
-        assert t.children[1].operator == "SKIP"
-        assert t.children[1].success is True
-        assert t.children[2].operator == "leaf"
+    def test_skip_in_nary_or(self):
+        """fail_skip with 3 children OR — all evaluated, structure is flat."""
+        p = any_of([
+            leaf("A", result=False),
+            leaf_raiser("B", ValueError("boom")),
+            leaf("C", result=True),
+        ])
+        t = p(CTX, trace=True, short_circuit=False, fail_skip=(ValueError,))
+
+        assert trace_shape(t) == (
+            "or",
+            True,
+            None,
+            (
+                ("leaf", False, "A", ()),
+                ("SKIP", False, "B", ()),  # OR identity fallback
+                ("leaf", True, "C", ()),
+            ),
+        )
+
+    def test_skip_preserves_error_and_context(self):
+        """SKIP node carries the original exception and context value."""
+        err = ValueError("test_error")
+        p = leaf_raiser("A", err)
+        t = p(CTX, trace=True, fail_skip=(ValueError,))
+
+        assert t.operator == "SKIP"
+        assert t.error is not None
+        assert str(t.error) == "test_error"
+        assert t.value == CTX
 
     def test_unlisted_exception_propagates(self):
         """Exceptions not in fail_skip tuple propagate normally."""
@@ -456,29 +665,31 @@ class TestTraceFailSkip:
 class TestTraceLeafIdentity:
     """Verify leaf Trace nodes carry correct metadata."""
 
-    def test_leaf_has_name(self):
-        """Leaf trace node carries the predicate name."""
+    def test_leaf_has_name_and_desc(self):
+        """Leaf trace node carries name and description."""
         p = leaf("my_rule", result=True)
         t = p(CTX, trace=True)
 
         assert t.node is not None
         assert t.node.name == "my_rule"
+        assert t.node.desc == "my_rule"
 
-    def test_leaf_has_desc(self):
-        """Leaf trace node carries the predicate description."""
-        p = leaf("my_rule", result=True)
+    def test_leaf_with_separate_name_and_desc(self):
+        """Leaf with different name and desc carries both."""
+        p = predicate(lambda _: True, name="rule_id", desc="Human-readable description")
         t = p(CTX, trace=True)
 
         assert t.node is not None
-        assert t.node.desc == "my_rule"
+        assert t.node.name == "rule_id"
+        assert t.node.desc == "Human-readable description"
 
-    def test_leaf_success_matches_result(self):
-        """Leaf trace success matches the predicate return value."""
-        p_true = leaf("yes", result=True)
-        p_false = leaf("no", result=False)
+    def test_leaf_success_true(self):
+        p = leaf("yes", result=True)
+        assert p(CTX, trace=True).success is True
 
-        assert p_true(CTX, trace=True).success is True
-        assert p_false(CTX, trace=True).success is False
+    def test_leaf_success_false(self):
+        p = leaf("no", result=False)
+        assert p(CTX, trace=True).success is False
 
 
 # ============================================================================
@@ -489,8 +700,8 @@ class TestTraceLeafIdentity:
 class TestDefaultTraceStyleRendering:
     """Verify trace rendering produces readable, correct output."""
 
-    def test_leaf_renders_with_name(self):
-        """Leaf with name/desc should render the name, not 'LEAF'."""
+    def test_leaf_renders_with_desc(self):
+        """Leaf with desc should render the desc, not 'LEAF'."""
         p = leaf("is_active", result=True)
         t = p(CTX, trace=True)
 
@@ -499,14 +710,32 @@ class TestDefaultTraceStyleRendering:
         assert "LEAF" not in rendered
 
     def test_leaf_without_desc_falls_back_to_name(self):
-        """Leaf with name but no desc should render the name."""
+        """Leaf with name but no desc should render the name, not 'LEAF'."""
         p = predicate(lambda _: True, name="my_rule")
         t = p(CTX, trace=True)
 
         rendered = DefaultTraceStyle().render(t)
         assert "my_rule" in rendered
 
-    def test_and_node_renders_operator(self):
+    def test_success_icon(self):
+        """Successful trace uses check icon."""
+        t = Trace(success=True, operator="leaf")
+        rendered = DefaultTraceStyle().render(t)
+        assert "\u2705" in rendered  # ✅
+
+    def test_failure_icon(self):
+        """Failed trace uses cross icon."""
+        t = Trace(success=False, operator="leaf")
+        rendered = DefaultTraceStyle().render(t)
+        assert "\u274c" in rendered  # ❌
+
+    def test_skip_icon(self):
+        """SKIP trace uses skip icon."""
+        t = Trace(success=True, operator="SKIP")
+        rendered = DefaultTraceStyle().render(t)
+        assert "\u23ed" in rendered  # ⏭
+
+    def test_and_node_renders_operator_label(self):
         """AND node without desc renders 'AND'."""
         p = all_of([leaf("A", result=True), leaf("B", result=True)])
         t = p(CTX, trace=True, short_circuit=False)
@@ -516,25 +745,27 @@ class TestDefaultTraceStyleRendering:
 
     def test_failed_leaf_shows_context(self):
         """Failed leaf with value set shows context in render."""
-        t = Trace(
-            success=False,
-            operator="leaf",
-            value={"key": "val"},
-        )
+        t = Trace(success=False, operator="leaf", value={"key": "val"})
         rendered = DefaultTraceStyle().render(t)
         assert "Context" in rendered
+        assert "key" in rendered
 
     def test_skip_node_shows_error(self):
         """SKIP node renders error information."""
-        err = ValueError("test error")
-        t = Trace(
-            success=True,
-            operator="SKIP",
-            error=err,
-        )
+        t = Trace(success=True, operator="SKIP", error=ValueError("test error"))
         rendered = DefaultTraceStyle().render(t)
         assert "Error" in rendered
         assert "test error" in rendered
+
+    def test_nested_rendering_indentation(self):
+        """Nested trace produces indented output."""
+        inner = Trace(success=True, operator="leaf")
+        outer = Trace(success=True, operator="and", children=(inner,))
+        rendered = DefaultTraceStyle().render(outer)
+        lines = rendered.split("\n")
+        # Outer at level 0, inner at level 1 (indented)
+        assert len(lines) >= 2
+        assert lines[1].startswith("  ")  # 2-space indent
 
 
 # ============================================================================
@@ -543,54 +774,68 @@ class TestDefaultTraceStyleRendering:
 
 
 class TestTraceOperators:
-    """Verify Trace logical operator overloads."""
+    """Verify Trace logical operator overloads (public API)."""
 
-    def test_bool_reflects_success(self):
-        """bool(trace) returns trace.success."""
+    def test_bool_true(self):
         assert bool(Trace(success=True, operator="leaf")) is True
+
+    def test_bool_false(self):
         assert bool(Trace(success=False, operator="leaf")) is False
 
-    def test_and_operator(self):
-        """Trace & Trace produces and-trace."""
+    def test_and_both_true(self):
+        a = Trace(success=True, operator="leaf")
+        b = Trace(success=True, operator="leaf")
+        result = a & b
+        assert result.operator == "and"
+        assert result.success is True
+        assert len(result.children) == 2
+
+    def test_and_one_false(self):
         a = Trace(success=True, operator="leaf")
         b = Trace(success=False, operator="leaf")
         result = a & b
-
         assert result.operator == "and"
         assert result.success is False
         assert len(result.children) == 2
 
-    def test_or_operator(self):
-        """Trace | Trace produces or-trace."""
+    def test_or_both_false(self):
+        a = Trace(success=False, operator="leaf")
+        b = Trace(success=False, operator="leaf")
+        result = a | b
+        assert result.operator == "or"
+        assert result.success is False
+        assert len(result.children) == 2
+
+    def test_or_one_true(self):
         a = Trace(success=False, operator="leaf")
         b = Trace(success=True, operator="leaf")
         result = a | b
-
         assert result.operator == "or"
         assert result.success is True
         assert len(result.children) == 2
 
-    def test_invert_operator(self):
-        """~Trace produces not-trace."""
+    def test_invert(self):
         a = Trace(success=True, operator="leaf")
         result = ~a
-
         assert result.operator == "not"
         assert result.success is False
         assert len(result.children) == 1
+        assert result.children[0] is a
+
+    def test_invert_false(self):
+        a = Trace(success=False, operator="leaf")
+        result = ~a
+        assert result.success is True
 
     def test_and_with_bool(self):
-        """Trace & bool works."""
         a = Trace(success=True, operator="leaf")
         result = a & False
-
-        assert result.operator == "and"
         assert result.success is False
+        # The bool should be wrapped as PURE_BOOL
+        assert result.children[1].operator == "PURE_BOOL"
 
     def test_or_with_bool(self):
-        """Trace | bool works."""
         a = Trace(success=False, operator="leaf")
         result = a | True
-
-        assert result.operator == "or"
         assert result.success is True
+        assert result.children[1].operator == "PURE_BOOL"

--- a/sdks/python/tests/test_trace.py
+++ b/sdks/python/tests/test_trace.py
@@ -1,0 +1,596 @@
+"""
+Test suite for Trace — PredyLogic's core observability mechanism.
+
+Covers:
+- Trace tree structure correctness (flat N-ary, not nested binary)
+- Short-circuit behavior and children collection
+- fail_skip interaction with Trace
+- Nested compositions (and/or/not combinations)
+- DefaultTraceStyle rendering
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+import pytest
+from predylogic import Trace, all_of, any_of, predicate
+from predylogic.trace.trace import DefaultTraceStyle
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+class Ctx(TypedDict):
+    value: int
+
+
+def leaf(name: str, *, result: bool):
+    """Create a named leaf predicate with a fixed result."""
+    return predicate(lambda _: result, name=name, desc=name)
+
+
+def leaf_raiser(name: str, exc: Exception):
+    """Create a named leaf that raises on evaluation."""
+
+    def _fn(_: Ctx) -> bool:
+        raise exc
+
+    return predicate(_fn, name=name, desc=name)
+
+
+CTX: Ctx = {"value": 1}
+
+
+def collect_operators(t: Trace) -> list[str]:
+    """Flatten all operators in a trace tree (pre-order)."""
+    ops = [t.operator]
+    for c in t.children:
+        ops.extend(collect_operators(c))
+    return ops  # ty:ignore[invalid-return-type]
+
+
+def collect_leaf_names(t: Trace) -> list[str]:
+    """Collect names of all leaf nodes in pre-order."""
+    names = []
+    if t.operator == "leaf" and t.node and t.node.name:
+        names.append(t.node.name)
+    for c in t.children:
+        names.extend(collect_leaf_names(c))
+    return names
+
+
+# ============================================================================
+# 1. Trace Tree Structure
+# ============================================================================
+
+
+class TestTraceTreeStructure:
+    """Verify Trace tree mirrors the logical structure — flat N-ary, not nested binary."""
+
+    def test_single_leaf(self):
+        """Single leaf produces a leaf Trace."""
+        p = leaf("A", result=True)
+        t = p(CTX, trace=True)
+
+        assert isinstance(t, Trace)
+        assert t.operator == "leaf"
+        assert t.success is True
+        assert t.children == ()
+        assert t.node is not None
+        assert t.node.name == "A"
+
+    def test_two_children_and(self):
+        """AND with 2 children — baseline, should be flat."""
+        p = all_of([leaf("A", result=True), leaf("B", result=False)])
+        t = p(CTX, trace=True, short_circuit=False)
+
+        assert t.operator == "and"
+        assert t.success is False
+        assert len(t.children) == 2
+        assert t.children[0].operator == "leaf"
+        assert t.children[1].operator == "leaf"
+
+    def test_two_children_or(self):
+        """OR with 2 children — baseline, should be flat."""
+        p = any_of([leaf("A", result=False), leaf("B", result=True)])
+        t = p(CTX, trace=True, short_circuit=False)
+
+        assert t.operator == "or"
+        assert t.success is True
+        assert len(t.children) == 2
+        assert t.children[0].operator == "leaf"
+        assert t.children[1].operator == "leaf"
+
+    def test_three_children_and_is_flat(self):
+        """
+        CRITICAL: all_of([A, B, C]) must produce a flat AND node with 3 children,
+        not a left-leaning nested tree.
+
+        Expected:
+            and -> [A, B, C]
+
+        NOT:
+            and -> [and -> [A, B], C]
+        """
+        p = all_of([
+            leaf("A", result=True),
+            leaf("B", result=False),
+            leaf("C", result=True),
+        ])
+        t = p(CTX, trace=True, short_circuit=False)
+
+        assert t.operator == "and"
+        assert t.success is False
+        assert len(t.children) == 3, (
+            f"Expected 3 flat children, got {len(t.children)}. Operators: {[c.operator for c in t.children]}"
+        )
+        assert all(c.operator == "leaf" for c in t.children)
+        assert collect_leaf_names(t) == ["A", "B", "C"]
+
+    def test_three_children_or_is_flat(self):
+        """
+        CRITICAL: any_of([A, B, C]) must produce a flat OR node with 3 children.
+        """
+        p = any_of([
+            leaf("A", result=False),
+            leaf("B", result=True),
+            leaf("C", result=False),
+        ])
+        t = p(CTX, trace=True, short_circuit=False)
+
+        assert t.operator == "or"
+        assert t.success is True
+        assert len(t.children) == 3, (
+            f"Expected 3 flat children, got {len(t.children)}. Operators: {[c.operator for c in t.children]}"
+        )
+        assert all(c.operator == "leaf" for c in t.children)
+        assert collect_leaf_names(t) == ["A", "B", "C"]
+
+    def test_four_children_and_is_flat(self):
+        """4 children AND — no nesting at any level."""
+        p = all_of([
+            leaf("A", result=True),
+            leaf("B", result=True),
+            leaf("C", result=True),
+            leaf("D", result=False),
+        ])
+        t = p(CTX, trace=True, short_circuit=False)
+
+        assert t.operator == "and"
+        assert len(t.children) == 4
+        assert all(c.operator == "leaf" for c in t.children)
+        assert t.success is False
+
+    def test_four_children_or_is_flat(self):
+        """4 children OR — no nesting at any level."""
+        p = any_of([
+            leaf("A", result=False),
+            leaf("B", result=False),
+            leaf("C", result=True),
+            leaf("D", result=False),
+        ])
+        t = p(CTX, trace=True, short_circuit=False)
+
+        assert t.operator == "or"
+        assert len(t.children) == 4
+        assert all(c.operator == "leaf" for c in t.children)
+        assert t.success is True
+
+    def test_chained_and_operator_is_flat(self):
+        """
+        A & B & C via operator chaining should also produce flat trace.
+        """
+        a = leaf("A", result=True)
+        b = leaf("B", result=True)
+        c = leaf("C", result=False)
+
+        p = a & b & c
+        t = p(CTX, trace=True, short_circuit=False)
+
+        assert t.operator == "and"
+        assert len(t.children) == 3
+        assert all(c.operator == "leaf" for c in t.children)
+
+    def test_chained_or_operator_is_flat(self):
+        """
+        A | B | C via operator chaining should also produce flat trace.
+        """
+        a = leaf("A", result=False)
+        b = leaf("B", result=False)
+        c = leaf("C", result=True)
+
+        p = a | b | c
+        t = p(CTX, trace=True, short_circuit=False)
+
+        assert t.operator == "or"
+        assert len(t.children) == 3
+        assert all(c.operator == "leaf" for c in t.children)
+
+
+# ============================================================================
+# 2. Nested Compositions
+# ============================================================================
+
+
+class TestTraceNestedComposition:
+    """Verify Trace structure for nested logical compositions."""
+
+    def test_and_containing_or(self):
+        """AND(A, OR(B, C)) — two levels, each correct."""
+        p = all_of([
+            leaf("A", result=True),
+            any_of([leaf("B", result=False), leaf("C", result=True)]),
+        ])
+        t = p(CTX, trace=True, short_circuit=False)
+
+        assert t.operator == "and"
+        assert t.success is True
+        assert len(t.children) == 2
+
+        assert t.children[0].operator == "leaf"
+        assert t.children[1].operator == "or"
+        assert len(t.children[1].children) == 2
+
+    def test_or_containing_and(self):
+        """OR(AND(A, B), C) — two levels."""
+        p = any_of([
+            all_of([leaf("A", result=False), leaf("B", result=True)]),
+            leaf("C", result=True),
+        ])
+        t = p(CTX, trace=True, short_circuit=False)
+
+        assert t.operator == "or"
+        assert t.success is True
+        assert len(t.children) == 2
+
+        assert t.children[0].operator == "and"
+        assert t.children[0].success is False
+        assert t.children[1].operator == "leaf"
+
+    def test_not_wrapping_and(self):
+        """NOT(AND(A, B)) — not node with and child."""
+        p = ~all_of([leaf("A", result=True), leaf("B", result=True)])
+        t = p(CTX, trace=True, short_circuit=False)
+
+        assert t.operator == "not"
+        assert t.success is False
+        assert len(t.children) == 1
+        assert t.children[0].operator == "and"
+        assert t.children[0].success is True
+
+    def test_three_level_nesting(self):
+        """AND(A, OR(B, AND(C, D))) — three levels deep."""
+        p = all_of([
+            leaf("A", result=True),
+            any_of([
+                leaf("B", result=False),
+                all_of([leaf("C", result=True), leaf("D", result=True)]),
+            ]),
+        ])
+        t = p(CTX, trace=True, short_circuit=False)
+
+        assert t.operator == "and"
+        assert t.success is True
+        assert len(t.children) == 2
+
+        or_node = t.children[1]
+        assert or_node.operator == "or"
+        assert len(or_node.children) == 2
+
+        and_inner = or_node.children[1]
+        assert and_inner.operator == "and"
+        assert len(and_inner.children) == 2
+        assert all(c.operator == "leaf" for c in and_inner.children)
+
+    def test_nary_and_containing_nary_or(self):
+        """
+        all_of([A, B, any_of([C, D, E])]) — N-ary at both levels.
+        Both AND and OR nodes should be flat.
+        """
+        p = all_of([
+            leaf("A", result=True),
+            leaf("B", result=True),
+            any_of([
+                leaf("C", result=False),
+                leaf("D", result=False),
+                leaf("E", result=True),
+            ]),
+        ])
+        t = p(CTX, trace=True, short_circuit=False)
+
+        assert t.operator == "and"
+        assert t.success is True
+        assert len(t.children) == 3
+
+        or_node = t.children[2]
+        assert or_node.operator == "or"
+        assert len(or_node.children) == 3
+        assert all(c.operator == "leaf" for c in or_node.children)
+
+
+# ============================================================================
+# 3. Short-Circuit Behavior
+# ============================================================================
+
+
+class TestTraceShortCircuit:
+    """Verify short-circuit trace captures evaluated nodes only."""
+
+    def test_and_short_circuits_on_first_false(self):
+        """AND(F, T, T) with short_circuit=True — only first child evaluated."""
+        p = all_of([
+            leaf("A", result=False),
+            leaf("B", result=True),
+            leaf("C", result=True),
+        ])
+        t = p(CTX, trace=True, short_circuit=True)
+
+        assert t.operator == "and"
+        assert t.success is False
+        evaluated = collect_leaf_names(t)
+        assert "A" in evaluated
+        assert "B" not in evaluated
+        assert "C" not in evaluated
+
+    def test_or_short_circuits_on_first_true(self):
+        """OR(T, F, F) with short_circuit=True — only first child evaluated."""
+        p = any_of([
+            leaf("A", result=True),
+            leaf("B", result=False),
+            leaf("C", result=False),
+        ])
+        t = p(CTX, trace=True, short_circuit=True)
+
+        assert t.operator == "or"
+        assert t.success is True
+        evaluated = collect_leaf_names(t)
+        assert "A" in evaluated
+        assert "B" not in evaluated
+        assert "C" not in evaluated
+
+    def test_and_short_circuits_on_second(self):
+        """AND(T, F, T) — evaluates A and B, stops at B."""
+        p = all_of([
+            leaf("A", result=True),
+            leaf("B", result=False),
+            leaf("C", result=True),
+        ])
+        t = p(CTX, trace=True, short_circuit=True)
+
+        assert t.success is False
+        evaluated = collect_leaf_names(t)
+        assert "A" in evaluated
+        assert "B" in evaluated
+        assert "C" not in evaluated
+
+    def test_no_short_circuit_evaluates_all(self):
+        """AND(F, T, T) with short_circuit=False — all children evaluated."""
+        p = all_of([
+            leaf("A", result=False),
+            leaf("B", result=True),
+            leaf("C", result=True),
+        ])
+        t = p(CTX, trace=True, short_circuit=False)
+
+        assert t.success is False
+        evaluated = collect_leaf_names(t)
+        assert evaluated == ["A", "B", "C"]
+
+
+# ============================================================================
+# 4. fail_skip Interaction
+# ============================================================================
+
+
+class TestTraceFailSkip:
+    """Verify fail_skip produces SKIP trace nodes with correct metadata."""
+
+    def test_skip_node_in_and_context(self):
+        """Skipped node in AND context gets fallback=True (AND identity)."""
+        p = all_of([
+            leaf_raiser("A", ValueError("boom")),
+            leaf("B", result=False),
+        ])
+        t = p(CTX, trace=True, short_circuit=False, fail_skip=(ValueError,))
+
+        assert t.operator == "and"
+        assert t.success is False
+
+        skip_child = t.children[0]
+        assert skip_child.operator == "SKIP"
+        assert skip_child.success is True  # AND identity
+        assert skip_child.error is not None
+        assert isinstance(skip_child.error, ValueError)
+        assert skip_child.node is not None
+        assert skip_child.node.name == "A"
+
+    def test_skip_node_in_or_context(self):
+        """Skipped node in OR context gets fallback=False (OR identity)."""
+        p = any_of([
+            leaf_raiser("A", ValueError("boom")),
+            leaf("B", result=True),
+        ])
+        t = p(CTX, trace=True, short_circuit=False, fail_skip=(ValueError,))
+
+        assert t.operator == "or"
+        assert t.success is True
+
+        skip_child = t.children[0]
+        assert skip_child.operator == "SKIP"
+        assert skip_child.success is False  # OR identity
+        assert isinstance(skip_child.error, ValueError)
+
+    def test_skip_in_nary_and(self):
+        """fail_skip with 3 children AND — all evaluated, skip is flat."""
+        p = all_of([
+            leaf("A", result=True),
+            leaf_raiser("B", ValueError("boom")),
+            leaf("C", result=True),
+        ])
+        t = p(CTX, trace=True, short_circuit=False, fail_skip=(ValueError,))
+
+        assert t.operator == "and"
+        assert t.success is True  # A=True, B=True(skip identity), C=True
+        assert len(t.children) == 3
+
+        assert t.children[0].operator == "leaf"
+        assert t.children[1].operator == "SKIP"
+        assert t.children[1].success is True
+        assert t.children[2].operator == "leaf"
+
+    def test_unlisted_exception_propagates(self):
+        """Exceptions not in fail_skip tuple propagate normally."""
+        p = leaf_raiser("A", KeyError("nope"))
+
+        with pytest.raises(KeyError):
+            p(CTX, trace=True, fail_skip=(ValueError,))
+
+
+# ============================================================================
+# 5. Trace Leaf Identity
+# ============================================================================
+
+
+class TestTraceLeafIdentity:
+    """Verify leaf Trace nodes carry correct metadata."""
+
+    def test_leaf_has_name(self):
+        """Leaf trace node carries the predicate name."""
+        p = leaf("my_rule", result=True)
+        t = p(CTX, trace=True)
+
+        assert t.node is not None
+        assert t.node.name == "my_rule"
+
+    def test_leaf_has_desc(self):
+        """Leaf trace node carries the predicate description."""
+        p = leaf("my_rule", result=True)
+        t = p(CTX, trace=True)
+
+        assert t.node is not None
+        assert t.node.desc == "my_rule"
+
+    def test_leaf_success_matches_result(self):
+        """Leaf trace success matches the predicate return value."""
+        p_true = leaf("yes", result=True)
+        p_false = leaf("no", result=False)
+
+        assert p_true(CTX, trace=True).success is True
+        assert p_false(CTX, trace=True).success is False
+
+
+# ============================================================================
+# 6. DefaultTraceStyle Rendering
+# ============================================================================
+
+
+class TestDefaultTraceStyleRendering:
+    """Verify trace rendering produces readable, correct output."""
+
+    def test_leaf_renders_with_name(self):
+        """Leaf with name/desc should render the name, not 'LEAF'."""
+        p = leaf("is_active", result=True)
+        t = p(CTX, trace=True)
+
+        rendered = DefaultTraceStyle().render(t)
+        assert "is_active" in rendered
+        assert "LEAF" not in rendered
+
+    def test_leaf_without_desc_falls_back_to_name(self):
+        """Leaf with name but no desc should render the name."""
+        p = predicate(lambda _: True, name="my_rule")
+        t = p(CTX, trace=True)
+
+        rendered = DefaultTraceStyle().render(t)
+        assert "my_rule" in rendered
+
+    def test_and_node_renders_operator(self):
+        """AND node without desc renders 'AND'."""
+        p = all_of([leaf("A", result=True), leaf("B", result=True)])
+        t = p(CTX, trace=True, short_circuit=False)
+
+        rendered = DefaultTraceStyle().render(t)
+        assert "AND" in rendered
+
+    def test_failed_leaf_shows_context(self):
+        """Failed leaf with value set shows context in render."""
+        t = Trace(
+            success=False,
+            operator="leaf",
+            value={"key": "val"},
+        )
+        rendered = DefaultTraceStyle().render(t)
+        assert "Context" in rendered
+
+    def test_skip_node_shows_error(self):
+        """SKIP node renders error information."""
+        err = ValueError("test error")
+        t = Trace(
+            success=True,
+            operator="SKIP",
+            error=err,
+        )
+        rendered = DefaultTraceStyle().render(t)
+        assert "Error" in rendered
+        assert "test error" in rendered
+
+
+# ============================================================================
+# 7. Trace __bool__ and Operator Overloads
+# ============================================================================
+
+
+class TestTraceOperators:
+    """Verify Trace logical operator overloads."""
+
+    def test_bool_reflects_success(self):
+        """bool(trace) returns trace.success."""
+        assert bool(Trace(success=True, operator="leaf")) is True
+        assert bool(Trace(success=False, operator="leaf")) is False
+
+    def test_and_operator(self):
+        """Trace & Trace produces and-trace."""
+        a = Trace(success=True, operator="leaf")
+        b = Trace(success=False, operator="leaf")
+        result = a & b
+
+        assert result.operator == "and"
+        assert result.success is False
+        assert len(result.children) == 2
+
+    def test_or_operator(self):
+        """Trace | Trace produces or-trace."""
+        a = Trace(success=False, operator="leaf")
+        b = Trace(success=True, operator="leaf")
+        result = a | b
+
+        assert result.operator == "or"
+        assert result.success is True
+        assert len(result.children) == 2
+
+    def test_invert_operator(self):
+        """~Trace produces not-trace."""
+        a = Trace(success=True, operator="leaf")
+        result = ~a
+
+        assert result.operator == "not"
+        assert result.success is False
+        assert len(result.children) == 1
+
+    def test_and_with_bool(self):
+        """Trace & bool works."""
+        a = Trace(success=True, operator="leaf")
+        result = a & False
+
+        assert result.operator == "and"
+        assert result.success is False
+
+    def test_or_with_bool(self):
+        """Trace | bool works."""
+        a = Trace(success=False, operator="leaf")
+        result = a | True
+
+        assert result.operator == "or"
+        assert result.success is True


### PR DESCRIPTION
## Description

Closes #38

Fixes the Trace subsystem so `all_of([A, B, C])` and `A & B & C` both produce a flat 3-child AND node in `[A, B, C]` order, and leaf nodes render their `name` when `desc` is absent.

Before:
```
AND(AND(A, C), B)        # nested, out-of-order
```
After:
```
AND(A, B, C)             # flat, in-order
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Chore

## Checklist

- [x] My code follows the style guidelines of this project (`just py-check` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective (test suite added in preceding commits, now passing: 16 failed → 0 failed)
- [x] New and existing unit tests pass locally with my changes (`just test`)
- [ ] I have updated the `CHANGELOG.md` (if applicable)

## Implementation Details / Benchmarks

Four related fixes in `predicate/predicate.py` and `trace/trace.py`:

**1. `_collect_chain` N-ary ordering** — The function's contract is to return children in reversed execution order (so the LIFO compile stack restores left-to-right). The binary branch obeyed this, but the N-ary branch appended `children[1:]` without reversing. Fixed by wrapping in `reversed(...)`.

**2. FLATTENED marker count** (pre-existing, unblocked by fix 1) — `flat_tuple = ("FLATTENED", node_type, len(children))` used the top-level `len(children)`, but `_collect_chain` walks into same-type descendants and can return a longer chain. For binary-chained `A & B & C` (top-level `len == 2`, chain len 3), the marker consumed only 2 expressions from the results stack, silently orphaning the first leaf. Fixed by materializing the chain first and using `len(chain)`.

**3. `_rt_and` / `_rt_or` build flat N-ary Trace** — The runtime helpers accumulated children via `Trace.__and__` / `__or__`, which always produces binary nodes. Rewritten to collect children into a list and construct a single N-ary `Trace` at return time. Short-circuit paths still return only the children that were actually evaluated, so the short-circuit tests pass unchanged.

**4. `DefaultTraceStyle.render` name fallback** — Previously rendered `LEAF` when `node.desc` was absent, even if `node.name` was set. Now falls back to `node.name`.

### Test results

- `tests/test_trace.py`: 16 failed → **0 failed** (54/54 pass)
- Full Python suite: **133/133 pass**
- `just py-check` (ty + ruff + deptry + tach): all green

### Scope notes

Fix #2 is a true semantic bug that was latent in bool mode too — `A(False) & B(True) & C(True)` would compile to `return B and C` and evaluate to `True`. Existing tests didn't exercise this combination, which is why it wasn't caught earlier. Fix is minimal: compute the flatten count from the actual walked chain length.

No changes to the non-trace fast path's AST generation — the fix is contained to chain length accounting, trace helpers, and the renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)