### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-codecov-config.yml
+++ b/.github/workflows/validate-codecov-config.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   validate-codecov-config:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Nagato-Yuzuru/predylogic/security/code-scanning/2](https://github.com/Nagato-Yuzuru/predylogic/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is restricted to least privilege.  
Best fix: define workflow-level permissions with `contents: read`, since all jobs in this workflow (currently one) only need read access for checkout and config validation. This keeps behavior unchanged while satisfying CodeQL and hardening security.

Edit **`.github/workflows/validate-codecov-config.yml`** by inserting:

```yaml
permissions:
  contents: read
```

between the `on:` section and `jobs:` (or at another valid top-level location). No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
