### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-benchmark.yml
+++ b/.github/workflows/python-benchmark.yml
@@ -16,6 +16,9 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   benchmarks:
     name: Run CodSpeed


### PR DESCRIPTION
Potential fix for [https://github.com/Nagato-Yuzuru/predylogic/security/code-scanning/5](https://github.com/Nagato-Yuzuru/predylogic/security/code-scanning/5)

Add an explicit `permissions` block to `.github/workflows/python-benchmark.yml` so the workflow token is constrained by default.  
Best fix without changing functionality: define permissions at the workflow root (applies to all jobs) with the minimum required scope:

- `contents: read`

This supports `actions/checkout` and benchmark execution while enforcing least privilege.  
Change location: immediately after the trigger section (`on:` block) and before `jobs:`.

No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
