### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -12,6 +12,8 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+permissions:
+  contents: read
 
 jobs:
   quality-python:
@@ -31,6 +33,7 @@ jobs:
 
   tests-and-type-check:
     permissions:
+      contents: read
       id-token: write
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/Nagato-Yuzuru/predylogic/security/code-scanning/8](https://github.com/Nagato-Yuzuru/predylogic/security/code-scanning/8)

Add an explicit `permissions` block at the workflow root so all jobs are constrained by default, and keep/expand job-level permissions only where needed.

Best fix here without changing behavior:
- Add top-level:
  - `contents: read` (needed by checkout/read operations)
- Update `tests-and-type-check` job permissions to include:
  - `contents: read`
  - `id-token: write` (already needed for Codecov OIDC)

This ensures:
- `quality-python` and `check-docs` get least-privilege read access.
- `tests-and-type-check` retains required OIDC capability while still explicitly allowing repository content read.

Edit only `.github/workflows/python-ci.yml`:
- Insert root `permissions` block after triggers (`workflow_dispatch:`) and before `jobs:`.
- Replace current `tests-and-type-check.permissions` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
