### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -64,6 +64,8 @@ jobs:
           fail_ci_if_error: true
 
   check-docs:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Check out


### PR DESCRIPTION
Potential fix for [https://github.com/Nagato-Yuzuru/predylogic/security/code-scanning/9](https://github.com/Nagato-Yuzuru/predylogic/security/code-scanning/9)

Add an explicit `permissions` block to the `check-docs` job in `.github/workflows/python-ci.yml`, setting:

- `contents: read`

This is the least-privilege setting needed for checking out repository contents and running documentation build commands. It does not change functional behavior, only hardens token scope.

Change location:
- File: `.github/workflows/python-ci.yml`
- Region: `jobs.check-docs` (around current lines 66–68), directly under `check-docs:` and before `runs-on:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
